### PR TITLE
Fix a logical error in retrieving unmatched basic block

### DIFF
--- a/src/bindiff/bindiff.py
+++ b/src/bindiff/bindiff.py
@@ -145,8 +145,8 @@ class BinDiff(BindiffFile):
                 # The block has been match but in another function thus unmatched here
                 if function.addr not in maps:
                     bbs.append(bb)
-                else:
-                    bbs.append(bb)
+            else:
+                bbs.append(bb)
         return bbs
 
     def primary_unmatched_basic_block(


### PR DESCRIPTION
Original codes erroneously treat matched basic blocks of a function as unmatched basic blocks